### PR TITLE
Release v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: Mahesh901122
 Tags: pixabay, pixabay images, free images, free stock images, image search, images, photos, stock images, royalty free images
 Donate link: https://www.paypal.me/mwaghmare7/
 Tested up to: 5.4
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 Requires at least: 4.4
 
 Download royalty free images/photos under CC0 public domain for your own blog. Select images/photos from 1.4 million royalty free stock photos.
@@ -51,6 +51,11 @@ Download royalty free images/photos under CC0 public domain for your own blog. S
 4. Click on 'Download' to download the image.
 
 == Changelog ==
+
+= 1.2.2
+* New: Downloaded the 1280xauto image by default. We also have a choice to download the 640xauto image size. Reported by @krstarica.
+* Improvement: Search result string messed up with the quick doc link.
+* Improvement: Removed `<span class="info">…</span>` part form the image caption. Reported by @krstarica
 
 = 1.2.1 =
 * Improvement: Register the download images page only for the `upload_files` user permissions. Reported by Steve.

--- a/assets/js/shortcode.js
+++ b/assets/js/shortcode.js
@@ -169,7 +169,7 @@
 					var template = wp.template( 'free-images-found-images' );
 					var search_term = $( '#search-image' ).val() || '';
 					if( search_term ) {
-						$('.search-form').append( template( { search_term : search_term, total : data.total }) );
+						$('.wp-header').append( template( { search_term : search_term, total : data.total }) );
 					}
 
                     FreeImages._initLightbox();

--- a/classes/class-free-images.php
+++ b/classes/class-free-images.php
@@ -261,7 +261,7 @@ if ( ! class_exists( 'Free_Images' ) ) :
 				'post_title'     => preg_replace( '/\.[^.]+$/', '', basename( $file_abs_url ) ),
 				'post_status'    => 'inherit',
 				'post_title'     => ucwords( $image_name ),
-				'post_excerpt'   => '<a href="' . $args['user_url'] . '">' . $args['user_name'] . '</a> / Pixabay <span class="info"><a href="https://maheshwaghmare.com/?p=8155" target="_blank" style="border:none;"><svg style="width: 14px;display:inline-block;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 15 15"><path d="M7.5,1.5a6,6,0,1,0,0,12a6,6,0,1,0,0,-12m0,1a5,5,0,1,1,0,10a5,5,0,1,1,0,-10ZM6.625,11l1.75,0l0,-4.5l-1.75,0ZM7.5,3.75a1,1,0,1,0,0,2a1,1,0,1,0,0,-2Z"></path></svg></a></span>',
+				'post_excerpt'   => '<a href="' . $args['user_url'] . '">' . $args['user_name'] . '</a> / Pixabay',
 				'meta_input'     => array(
 					'_wp_attachment_image_alt' => ucwords( $image_name ) . ' - ' . $args['user_name'] . ' / Pixabay',
 				),

--- a/free-images.php
+++ b/free-images.php
@@ -5,17 +5,15 @@
  * Plugin URI: https://profiles.wordpress.org/mahesh901122/
  * Author: Mahesh M. Waghmare
  * Author URI: https://maheshwaghmare.com/
- * Version: 1.2.1
+ * Version: 1.2.2
  * License: GNU General Public License v2.0
  * Text Domain: free-images
  *
  * @package Free Images
  */
 
-/**
- * Set constants.
- */
-define( 'FREE_IMAGES_VER', '1.2.1' );
+// Set constants.
+define( 'FREE_IMAGES_VER', '1.2.2' );
 define( 'FREE_IMAGES_FILE', __FILE__ );
 define( 'FREE_IMAGES_BASE', plugin_basename( FREE_IMAGES_FILE ) );
 define( 'FREE_IMAGES_DIR', plugin_dir_path( FREE_IMAGES_FILE ) );

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -76,14 +76,15 @@ defined( 'ABSPATH' ) or exit;
 ?>
 <script type="text/template" id="tmpl-free-images-list">
 	<# if( data ) { #>
+	<# console.log( data ); #>
 		<div class="image">
 			<div class="inner">
-				<a class="lightbox" data-id="{{data.id}}" data-preview-url="{{data.previewURL}}" data-user-image="{{data.userImageURL}}" data-url="{{data.webformatURL}}" data-user="{{data.user}}" data-user-name="{{data.user}}" href="{{data.webformatURL}}" data-user-url="https://pixabay.com/users/{{data.user}}" data-page-url="{{data.pageURL}}">
+				<a class="lightbox" data-id="{{data.id}}" data-preview-url="{{data.previewURL}}" data-user-image="{{data.userImageURL}}" data-url="{{data.largeImageURL}}" data-user="{{data.user}}" data-user-name="{{data.user}}" href="{{data.webformatURL}}" data-user-url="https://pixabay.com/users/{{data.user}}" data-page-url="{{data.pageURL}}">
 					<img class="lazy" data-src="{{data.webformatURL}}" /></a>
 					<noscript>
 						<img src="{{data.webformatURL}}" />
 					</noscript>
-				<div data-url="{{data.webformatURL}}" class="preview-and-download" data-user-name="{{data.user}}" data-user-url="https://pixabay.com/users/{{data.user}}" data-page-url="{{data.pageURL}}"></div>
+				<div data-url="{{data.largeImageURL}}" class="preview-and-download" data-user-name="{{data.user}}" data-user-url="https://pixabay.com/users/{{data.user}}" data-page-url="{{data.pageURL}}"></div>
 				<div class="meta">
 					<span class="user" data-user-id="{{data.user_id}}">
 						<img src="{{data.userImageURL}}" class="user-image-url">

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Mahesh901122
 Tags: pixabay, pixabay images, free images, free stock images, image search, images, photos, stock images, royalty free images
 Donate link: https://www.paypal.me/mwaghmare7/
 Tested up to: 5.4
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 Requires at least: 4.4
 
 Download royalty free images/photos under CC0 public domain for your own blog. Select images/photos from 1.4 million royalty free stock photos.
@@ -51,6 +51,11 @@ Download royalty free images/photos under CC0 public domain for your own blog. S
 4. Click on 'Download' to download the image.
 
 == Changelog ==
+
+= 1.2.2
+* New: Downloaded the 1280xauto image by default. We also have a choice to download the 640xauto image size. Reported by @krstarica.
+* Improvement: Search result string messed up with the quick doc link.
+* Improvement: Removed `<span class="info">…</span>` part form the image caption. Reported by @krstarica
 
 = 1.2.1 =
 * Improvement: Register the download images page only for the `upload_files` user permissions. Reported by Steve.


### PR DESCRIPTION
* New: Downloaded the 1280xauto image by default. We also have a choice to download the 640xauto image size. Reported by @krstarica.
* Improvement: Search result string messed up with the quick doc link.
* Improvement: Removed `<span class="info">…</span>` part form the image caption. Reported by @krstarica
